### PR TITLE
Don't unindent when shift-spacing mid-line

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,11 @@ function indentOneSpace(isReverse: boolean): void {
             }
 
             if (isReverse) {// Move left
+                if (isSingleLineSelection && start.character === end.character &&
+                        lines[0].text.slice(0, selection.start.character).trim() !== '') {
+                    vscode.commands.executeCommand('type', { text: ' ' });
+                    return;
+                }
                 let isStartLineShifted = false;
                 let isEndLineShifted = false;
 


### PR DESCRIPTION
Although this no longer strictly matches the behaviour of shift-tab, I think it's more useful behaviour as it's easy to accidentally press shift-space mid-line, causing accidental unindents.

Fixes #3, though if it's preferable to be behind a setting, I can add one.