### PR TITLE
Check for multiple selections per line

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,8 +26,13 @@ function isCompleteRange(selection: Selection, firstLine: TextLine, lastLine: Te
  * Main function of the extension. Indent either right or left
  */
 function indentOneSpace(editor: TextEditor, isReverse: boolean) {
-	const newSelections: Selection[] = [];
+	const selections = editor.selections.map(selection => selection.start.line);
+	if (selections.length != selections.filter((v, i, a) => a.indexOf(v) === i).length) {
+		commands.executeCommand('type', { text: ' ' });
+		return;
+	};
 
+	const newSelections: Selection[] = [];
 	editor.edit(builder => {
 		for (const selection of editor.selections) {
 			let start = selection.start;


### PR DESCRIPTION
This pull request checks if there is more than one selection on any given line, in the event that there is, the default behavior of a space is inserted. It works by comparing the number of lines selected and the number of selections.

![indent](https://user-images.githubusercontent.com/2276355/148592220-9e5a7c36-37ab-449f-9808-ffb981e67837.gif)

Before multiple selections on a single line caused unexpected behavior, and for unindenting, an `Error: Overlapping ranges are not allowed!` error occurred.