### PR TITLE
Ignore multiple same text selections

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,6 +32,13 @@ function indentOneSpace(editor: TextEditor, isReverse: boolean) {
 		commands.executeCommand('type', { text: ' ' });
 		return;
 	}
+
+	const textSelections = editor.selections.map(editor.document.getText);
+	if (new Set(textSelections).size === 1) {
+		commands.executeCommand('type', { text: ' ' });
+		return;
+	}
+
 	const newSelections: Selection[] = [];
 
 	editor.edit(builder => {


### PR DESCRIPTION
This prevents indenting lines when multiple selections are performed with "Add Next Occurence" (⌘-D).

Before:
![Before](https://github.com/usernamehw/vscode-indent-one-space/assets/2276355/3ffb1f32-c176-4400-99cd-38ddb04858e1)

After:
![After](https://github.com/usernamehw/vscode-indent-one-space/assets/2276355/079df167-0cbb-4874-ba39-4a84509e8ff0)
